### PR TITLE
Refactoring dbcc script to run without mysql server entry point and initialization

### DIFF
--- a/dbcc.sh
+++ b/dbcc.sh
@@ -24,13 +24,16 @@ fi
 while read CHANGE; do
 	CHANGES_FILE_PATH="$CHANGES_HOME$CHANGE"
 	if [ -f $CHANGES_FILE_PATH ]; then
+		echo "mysql --login-path=$LOGIN_PATH changesets -s -N -e SELECT applied FROM $APP_DB WHERE file_path='$CHANGE' LIMIT 1"
 		applied=`mysql --login-path="$LOGIN_PATH" changesets -s -N -e "SELECT applied FROM $APP_DB WHERE file_path='$CHANGE' LIMIT 1"`
 		if [ ${#applied} -eq 1 ]; then
 			echo "$CHANGE - has already been applied"
 		else
 			echo "Applying changeset - $CHANGE"
+			echo "mysql --login-path=$LOGIN_PATH refocus -s -N -e `cat $CHANGES_FILE_PATH`"
 			mysql --login-path="$LOGIN_PATH" refocus -s -N -e "`cat $CHANGES_FILE_PATH`"
 			if [ $? -eq 0 ]; then
+				echo "mysql --login-path=$LOGIN_PATH changesets -s -N -e INSERT INTO $APP_DB (file_path) VALUES ('$CHANGE')"
 				mysql --login-path="$LOGIN_PATH" changesets -s -N -e "INSERT INTO $APP_DB (file_path) VALUES ('$CHANGE')"
 				echo "Changeset successfully applied"
 			else

--- a/dbcc.sh
+++ b/dbcc.sh
@@ -24,16 +24,13 @@ fi
 while read CHANGE; do
 	CHANGES_FILE_PATH="$CHANGES_HOME$CHANGE"
 	if [ -f $CHANGES_FILE_PATH ]; then
-		echo "mysql --login-path=$LOGIN_PATH changesets -s -N -e SELECT applied FROM $APP_DB WHERE file_path='$CHANGE' LIMIT 1"
 		applied=`mysql --login-path="$LOGIN_PATH" changesets -s -N -e "SELECT applied FROM $APP_DB WHERE file_path='$CHANGE' LIMIT 1"`
 		if [ ${#applied} -eq 1 ]; then
 			echo "$CHANGE - has already been applied"
 		else
 			echo "Applying changeset - $CHANGE"
-			echo "mysql --login-path=$LOGIN_PATH refocus -s -N -e `cat $CHANGES_FILE_PATH`"
 			mysql --login-path="$LOGIN_PATH" refocus -s -N -e "`cat $CHANGES_FILE_PATH`"
 			if [ $? -eq 0 ]; then
-				echo "mysql --login-path=$LOGIN_PATH changesets -s -N -e INSERT INTO $APP_DB (file_path) VALUES ('$CHANGE')"
 				mysql --login-path="$LOGIN_PATH" changesets -s -N -e "INSERT INTO $APP_DB (file_path) VALUES ('$CHANGE')"
 				echo "Changeset successfully applied"
 			else


### PR DESCRIPTION
Initially in order to run the database change set script we would actually start a mysql server and run the script file within the  docker-entrypoint-initdb.d folder. This update will allow us to use the mysql docker container as a mysql client along with a mounted login file to connect to the remote database for migration.